### PR TITLE
Support of configuration over wallabag:// protocol

### DIFF
--- a/src/wallabag/App.xaml.cs
+++ b/src/wallabag/App.xaml.cs
@@ -60,21 +60,13 @@ namespace wallabag
             else if (args.Kind == ActivationKind.Protocol)
             {
                 var a = args as ProtocolActivatedEventArgs;
-                var uriString = a.Uri.ToString().Replace("wallabag://", string.Empty);
+                var protocolParameter = ProtocolHelper.Parse(a.Uri.ToString());
 
-                var split = uriString.Split("@"[0]);
-
-                if (split.Length == 2)
+                if (protocolParameter != null && protocolParameter.Server.IsValidUri())
                 {
-                    var username = split[0];
-                    var server = split[1].Replace("https//", "https://").Replace("http//", "http://");
-
-                    if (server.IsValidUri())
-                    {
-                        NavigationService.Navigate(typeof(Views.LoginPage), new ProtocolSetupNavigationParameter(username, server));
-                        NavigationService.ClearCache();
-                        NavigationService.ClearHistory();
-                    }
+                    NavigationService.Navigate(typeof(Views.LoginPage), protocolParameter);
+                    NavigationService.ClearCache();
+                    NavigationService.ClearHistory();
                 }
             }
             else

--- a/src/wallabag/App.xaml.cs
+++ b/src/wallabag/App.xaml.cs
@@ -69,7 +69,12 @@ namespace wallabag
                     var username = split[0];
                     var server = split[1].Replace("https//", "https://").Replace("http//", "http://");
 
-                    NavigationService.Navigate(typeof(Views.LoginPage), new ProtocolSetupNavigationParameter(username, server));
+                    if (server.IsValidUri())
+                    {
+                        NavigationService.Navigate(typeof(Views.LoginPage), new ProtocolSetupNavigationParameter(username, server));
+                        NavigationService.ClearCache();
+                        NavigationService.ClearHistory();
+                    }
                 }
             }
             else

--- a/src/wallabag/App.xaml.cs
+++ b/src/wallabag/App.xaml.cs
@@ -57,6 +57,21 @@ namespace wallabag
                 SessionState["shareTarget"] = args;
                 NavigationService.Navigate(typeof(Views.ShareTargetPage));
             }
+            else if (args.Kind == ActivationKind.Protocol)
+            {
+                var a = args as ProtocolActivatedEventArgs;
+                var uriString = a.Uri.ToString().Replace("wallabag://", string.Empty);
+
+                var split = uriString.Split("@"[0]);
+
+                if (split.Length == 2)
+                {
+                    var username = split[0];
+                    var server = split[1].Replace("https//", "https://").Replace("http//", "http://");
+
+                    NavigationService.Navigate(typeof(Views.LoginPage), new ProtocolSetupNavigationParameter(username, server));
+                }
+            }
             else
             {
                 if (string.IsNullOrEmpty(Settings.AccessToken) || string.IsNullOrEmpty(Settings.RefreshToken))

--- a/src/wallabag/Common/Helpers/ProtocolHelper.cs
+++ b/src/wallabag/Common/Helpers/ProtocolHelper.cs
@@ -1,0 +1,23 @@
+﻿using wallabag.Models;
+
+namespace wallabag.Common.Helpers
+{
+    public static class ProtocolHelper
+    {
+        private  const string PROTOCOL_HANDLER = "wallabag://";
+        public static ProtocolSetupNavigationParameter Parse(string str)
+        {
+            ProtocolSetupNavigationParameter result = null;
+
+            if (str.StartsWith(PROTOCOL_HANDLER))
+                str = str.Remove(0, PROTOCOL_HANDLER.Length);
+
+            var split = str.Split("@"[0]);
+
+            if (split.Length == 2)
+                result = new ProtocolSetupNavigationParameter(split[0], split[1].Replace("https//", "https://").Replace("http//", "http://"));
+
+            return result;
+        }
+    }
+}

--- a/src/wallabag/Models/ProtocolSetupNavigationParameter.cs
+++ b/src/wallabag/Models/ProtocolSetupNavigationParameter.cs
@@ -1,0 +1,14 @@
+﻿namespace wallabag.Models
+{
+    public class ProtocolSetupNavigationParameter
+    {
+        public ProtocolSetupNavigationParameter(string username, string server)
+        {
+            Username = username;
+            Server = server;
+        }
+
+        public string Username { get; set; }
+        public string Server { get; set; }
+    }
+}

--- a/src/wallabag/Models/WallabagProvider.cs
+++ b/src/wallabag/Models/WallabagProvider.cs
@@ -1,5 +1,6 @@
 ﻿using PropertyChanged;
 using System;
+using wallabag.Common.Helpers;
 
 namespace wallabag.Models
 {
@@ -9,6 +10,7 @@ namespace wallabag.Models
         public string Name { get; set; }
         public Uri Url { get; set; }
         public string ShortDescription { get; set; }
+        public static WallabagProvider Other { get; } = new WallabagProvider(default(Uri), GeneralHelper.LocalizedResource("OtherProviderName"), GeneralHelper.LocalizedResource("OtherProviderDescription"));
 
         public WallabagProvider(Uri url, string name, string shortDescription = "")
         {

--- a/src/wallabag/Package.appxmanifest
+++ b/src/wallabag/Package.appxmanifest
@@ -21,6 +21,11 @@
         <uap:SplashScreen Image="Assets\SplashScreen\SplashScreen.png" BackgroundColor="#000000" />
       </uap:VisualElements>
       <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="wallabag">
+            <uap:DisplayName>wallabag</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
         <uap:Extension Category="windows.shareTarget" EntryPoint="wallabag.App">
           <uap:ShareTarget Description="Save a link in your wallabag!">
             <uap:DataFormat>URI</uap:DataFormat>

--- a/src/wallabag/Package.appxmanifest
+++ b/src/wallabag/Package.appxmanifest
@@ -36,5 +36,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <DeviceCapability Name="microphone" />
+    <DeviceCapability Name="webcam" />
   </Capabilities>
 </Package>

--- a/src/wallabag/Strings/de-DE/Resources.resw
+++ b/src/wallabag/Strings/de-DE/Resources.resw
@@ -510,4 +510,10 @@
   <data name="MadeByHeaderTextBlock.Text" xml:space="preserve">
     <value>MIT VIEL HINGABE ENTWICKELT VON</value>
   </data>
+  <data name="HoldCameraOntoQRCodeMessage" xml:space="preserve">
+    <value>Halte die Kamera auf den QR-Code</value>
+  </data>
+  <data name="ScanQRCodeButton.Content" xml:space="preserve">
+    <value>QR-Code für Konfiguration scannen</value>
+  </data>
 </root>

--- a/src/wallabag/Strings/en-US/Resources.resw
+++ b/src/wallabag/Strings/en-US/Resources.resw
@@ -495,4 +495,10 @@
   <data name="MadeByHeaderTextBlock.Text" xml:space="preserve">
     <value>MADE WITH PASSION BY</value>
   </data>
+  <data name="HoldCameraOntoQRCodeMessage" xml:space="preserve">
+    <value>Hold the camera onto the QR code</value>
+  </data>
+  <data name="ScanQRCodeButton.Content" xml:space="preserve">
+    <value>Scan QR code for configuration</value>
+  </data>
 </root>

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -9,6 +9,7 @@ using wallabag.Api.Models;
 using wallabag.Common.Helpers;
 using wallabag.Models;
 using wallabag.Services;
+using Windows.Devices.Enumeration;
 using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.System;
 using Windows.UI.Core;
@@ -47,6 +48,8 @@ namespace wallabag.ViewModels
         public DelegateCommand RegisterCommand { get; private set; }
         public DelegateCommand WhatIsWallabagCommand { get; private set; }
         public DelegateCommand ScanQRCodeCommand { get; private set; }
+
+        public bool CameraIsSupported { get; set; } = false;
 
         public LoginPageViewModel()
         {
@@ -287,6 +290,8 @@ namespace wallabag.ViewModels
         public override async Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state)
         {
             _credentialsAreExisting = parameter != null && parameter is bool && (bool)parameter;
+
+            CameraIsSupported = (await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture)).Count > 0;
 
             if (state.Count > 0)
             {

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -51,7 +51,7 @@ namespace wallabag.ViewModels
             {
                 //new WallabagProvider(new Uri("https://framabag.org"), "framabag", GeneralHelper.LocalizedResource("FramabagProviderDescription")),
                 new WallabagProvider(new Uri("http://v2.wallabag.org"), "v2.wallabag.org", GeneralHelper.LocalizedResource("V2WallabagOrgProviderDescription")),
-                new WallabagProvider(default(Uri), GeneralHelper.LocalizedResource("OtherProviderName"),  GeneralHelper.LocalizedResource("OtherProviderDescription"))
+                WallabagProvider.Other
             };
 
             PreviousCommand = new DelegateCommand(() => Previous(), () => PreviousCanBeExecuted());
@@ -284,7 +284,7 @@ namespace wallabag.ViewModels
                 Username = np.Username;
                 Url = np.Server;
 
-                SelectedProvider = new WallabagProvider(new Uri(Url), string.Empty);
+                SelectedProvider = WallabagProvider.Other;
 
                 CurrentStep = 1;
                 return;

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -44,6 +44,7 @@ namespace wallabag.ViewModels
         public DelegateCommand RegisterCommand { get; private set; }
         public DelegateCommand WhatIsWallabagCommand { get; private set; }
         public Task TitleBarExtensions { get; private set; }
+        public DelegateCommand ScanQRCodeCommand { get; private set; }
 
         public LoginPageViewModel()
         {

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -110,7 +110,8 @@ namespace wallabag.ViewModels
 
             if (CurrentStep == 0)
             {
-                Url = selectedProvider?.Url == null ? "https://" : selectedProvider.Url.ToString();
+                if (Url.IsValidUri() == false)
+                    Url = selectedProvider?.Url == null ? "https://" : selectedProvider.Url.ToString();
 
                 CurrentStep += 1;
                 return;
@@ -249,7 +250,7 @@ namespace wallabag.ViewModels
 
         public override async Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state)
         {
-            _credentialsAreExisting = parameter != null && (bool)parameter;
+            _credentialsAreExisting = parameter != null && parameter is bool && (bool)parameter;
 
             if (state.Count > 0)
             {
@@ -274,6 +275,19 @@ namespace wallabag.ViewModels
                 Url = App.Client.InstanceUri.ToString();
 
                 await NextAsync();
+                return;
+            }
+
+            if (parameter is ProtocolSetupNavigationParameter)
+            {
+                var np = parameter as ProtocolSetupNavigationParameter;
+                Username = np.Username;
+                Url = np.Server;
+
+                SelectedProvider = new WallabagProvider(new Uri(Url), string.Empty);
+
+                CurrentStep = 1;
+                return;
             }
         }
         public override Task OnNavigatedFromAsync(IDictionary<string, object> pageState, bool suspending)

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -43,7 +43,6 @@ namespace wallabag.ViewModels
         public DelegateCommand NextCommand { get; private set; }
         public DelegateCommand RegisterCommand { get; private set; }
         public DelegateCommand WhatIsWallabagCommand { get; private set; }
-        public Task TitleBarExtensions { get; private set; }
         public DelegateCommand ScanQRCodeCommand { get; private set; }
 
         public LoginPageViewModel()

--- a/src/wallabag/ViewModels/LoginPageViewModel.cs
+++ b/src/wallabag/ViewModels/LoginPageViewModel.cs
@@ -76,7 +76,7 @@ namespace wallabag.ViewModels
                 var scanner = new ZXing.Mobile.MobileBarcodeScanner(CoreWindow.GetForCurrentThread().Dispatcher)
                 {
                     RootFrame = new Frame(),
-                    TopText = "Hold the camera onto the QR code"
+                    TopText = GeneralHelper.LocalizedResource("HoldCameraOntoQRCodeMessage")
                 };
 
                 rootModalDialog.Content = scanner.RootFrame;

--- a/src/wallabag/Views/LoginPage.xaml
+++ b/src/wallabag/Views/LoginPage.xaml
@@ -158,6 +158,7 @@
                         </ListView.ItemTemplate>
                     </ListView>
                     <Button
+                        x:Uid="ScanQRCodeButton"
                         Margin="4,8,4,4"
                         Command="{x:Bind ViewModel.ScanQRCodeCommand}"
                         Content="Scan QR code for configuration"

--- a/src/wallabag/Views/LoginPage.xaml
+++ b/src/wallabag/Views/LoginPage.xaml
@@ -158,8 +158,13 @@
                         </ListView.ItemTemplate>
                     </ListView>
                     <Button
-                        x:Uid="RegisterButton"
                         Margin="4,12,4,4"
+                        Command="{x:Bind ViewModel.ScanQRCodeCommand}"
+                        Content="Scan QR code for configuration"
+                        Style="{StaticResource TextBlockButtonStyle}" />
+                    <Button
+                        x:Uid="RegisterButton"
+                        Margin="4,6,4,4"
                         Command="{x:Bind ViewModel.RegisterCommand, Mode=OneWay}"
                         Content="Don't have an account yet? Create one!"
                         Style="{StaticResource TextBlockButtonStyle}" />

--- a/src/wallabag/Views/LoginPage.xaml
+++ b/src/wallabag/Views/LoginPage.xaml
@@ -158,10 +158,11 @@
                         </ListView.ItemTemplate>
                     </ListView>
                     <Button
-                        Margin="4,12,4,4"
+                        Margin="4,8,4,4"
                         Command="{x:Bind ViewModel.ScanQRCodeCommand}"
                         Content="Scan QR code for configuration"
-                        Style="{StaticResource TextBlockButtonStyle}" />
+                        Style="{StaticResource TextBlockButtonStyle}"
+                        Visibility="{x:Bind ViewModel.CameraIsSupported, Converter={StaticResource BooleanToVisibilityConverter}}" />
                     <Button
                         x:Uid="RegisterButton"
                         Margin="4,6,4,4"

--- a/src/wallabag/project.json
+++ b/src/wallabag/project.json
@@ -10,7 +10,8 @@
     "Template10": "1.1.12",
     "wallabag.Api": "1.3.2",
     "Win2D.uwp": "1.19.0",
-    "WindowsStateTriggers": "1.1.0"
+    "WindowsStateTriggers": "1.1.0",
+    "ZXing.Net.Mobile": "2.1.47"
   },
   "frameworks": {
     "uap10.0": {}

--- a/src/wallabag/wallabag.csproj
+++ b/src/wallabag/wallabag.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Common\Helpers\GeneralHelper.cs" />
     <Compile Include="Common\Helpers\DispatcherHelper.cs" />
     <Compile Include="Common\Helpers\ListHelper.cs" />
+    <Compile Include="Common\Helpers\ProtocolHelper.cs" />
     <Compile Include="Common\Helpers\StringHelper.cs" />
     <Compile Include="Common\Helpers\TitleBarHelper.cs" />
     <Compile Include="Common\Helpers\WebViewHelper.cs" />

--- a/src/wallabag/wallabag.csproj
+++ b/src/wallabag/wallabag.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Models\Item.cs" />
     <Compile Include="Models\Language.cs" />
     <Compile Include="Models\OfflineTask.cs" />
+    <Compile Include="Models\ProtocolSetupNavigationParameter.cs" />
     <Compile Include="Models\SearchProperties.cs" />
     <Compile Include="Models\Tag.cs" />
     <Compile Include="Models\WallabagProvider.cs" />


### PR DESCRIPTION
The QR code and the link to configure the application (see https://github.com/wallabag/wallabag/pull/2523) should be supported on the Windows app as well (the android app already supports it).

TODO:

- [x] Add support for the `wallabag://` configuration URL
- [x] Add a QR code scanner to the app to scan the code